### PR TITLE
IchigoJam FONT バージョン

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,18 +2,18 @@
 <html>
 
 <head>
-<style>
-@font-face {
-    font-family: "ichigojam";
-    font-style: normal;
-    font-weight: 400;
-    src: local('IchigoJam-1.4'), local('IchigoJam-1.4-Regular'),
-         url("https://cdn.jsdelivr.net/gh/fu-sen/ichigojam-font@20190814/IchigoJam-1.4.woff") format('woff');
-}
-a {
-    color: gray !important;
-}
-</style>
+    <style>
+    @font-face {
+        font-family: "ichigojam";
+        font-style: normal;
+        font-weight: 400;
+        src: local('IchigoJam-1.4'), local('IchigoJam-1.4-Regular'),
+            url("https://cdn.jsdelivr.net/gh/fu-sen/ichigojam-font@20190814/IchigoJam-1.4.woff") format('woff');
+    }
+    a {
+        color: gray !important;
+    }
+    </style>
 
     <meta charset="utf-8">
     <title>Webプログラミング 道場</title>

--- a/index.html
+++ b/index.html
@@ -26,7 +26,6 @@
             g_editor.setOptions({
                 fontFamily: "ichigojam",
                 fontSize: "12px",
-                lineHeght: "20px",
             });
             g_editor.container.style.lineHeight = 1.4;
             g_editor.renderer.updateFontSize();


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1715217/141538930-304b0f89-218b-41ed-8c8a-ef0a69ea07a5.png)
IchigoJamからのスムーズに移行できそうなフォント設定
Chromebookでも0とOの区別ができてやさしい